### PR TITLE
Corrected filename in documentation.

### DIFF
--- a/scripts/docker-build-orthanc/README.md
+++ b/scripts/docker-build-orthanc/README.md
@@ -1,6 +1,6 @@
 The folder contains files which allow to build the plugin inside a docker 
 container. You can also build the plugin in the native envirinment, just run
-only a script `build-s3-docker.sh`. First you need to comment final lines
+only a script `build-s3-plugin.sh`. First you need to comment final lines
 from the file (they are Docker-related) to avoid build error.
 
 If you want use Docker, then execute the following scripts:
@@ -15,5 +15,5 @@ remove them, one needs root priviledges.
 If you need to, customize the build process by editing the following file 
 (before building the image):
 
-    build-s3-docker.sh
+    build-s3-plugin.sh
 


### PR DESCRIPTION
I assume the correct name is build-s3-plugin.sh rather than build-s3-docker.sh