### PR TITLE
Update AwsSdkConfiguration.cmake

### DIFF
--- a/Resources/CMake/AwsSdkConfiguration.cmake
+++ b/Resources/CMake/AwsSdkConfiguration.cmake
@@ -2,7 +2,7 @@ set(USE_SYSTEM_AWS_SDK OFF CACHE BOOL "Use the system version of AWS SDK")
 
 if (NOT USE_SYSTEM_AWS_SDK)
     message("Getting AWS SDK from the web...")
-    SET(AWS_SDK_VERSION "1.7.28")
+    SET(AWS_SDK_VERSION "")
     SET(AWS_SDK_SOURCES_DIR ${CMAKE_BINARY_DIR}/aws-sdk-cpp-${AWS_SDK_VERSION})
     SET(AWS_SDK_BINARY_DIR ${CMAKE_BINARY_DIR}/aws-sdk-cpp-${AWS_SDK_VERSION}-build)
     SET(AWS_SDK_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/share/orthanc/aws)


### PR DESCRIPTION
Removed the version of the AWS SDK specified in the CMake file. This will make sure that the latest version is used. 